### PR TITLE
Improve provisioner idempotency and error handling

### DIFF
--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -1,8 +1,8 @@
 import {execute} from "./executor.ts";
-import {gitConfig, ifNotExists, shell, symlink, vscodeExtensions} from "./task.ts";
+import {brewBundle, defaults, gitConfig, ifNotExists, shell, symlink, vscodeExtensions} from "./task.ts";
 
 void execute(['username', 'email'], ({username, email}, {home}) => [
-  shell("brew bundle --no-upgrade"),
+  brewBundle(),
   // configure git
   gitConfig("user.name", username, {configFile: "~/.gitconfig.local"}),
   gitConfig("user.email", email, {configFile: "~/.gitconfig.local"}),
@@ -33,29 +33,36 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
   symlink(`${home}/.dotfiles/vscode/keybindings.json`, `${home}/Library/Application Support/Code/User/keybindings.json`),
   symlink(`${home}/.dotfiles/vscode/tasks.json`, `${home}/Library/Application Support/Code/User/tasks.json`),
   // osx defaults
-  shell("defaults write com.apple.dock autohide -bool true"),
-  shell("defaults write com.apple.dock persistent-apps -array"),
-  shell("defaults write com.apple.dock tilesize -int 55"),
-  shell("defaults write com.apple.finder AppleShowAllFiles YES"),
-  shell('defaults write com.apple.finder NewWindowTarget -string "PfDe"'),
-  shell(`defaults write com.apple.finder NewWindowTargetPath -string "file://${home}/"`),
-  shell('defaults write com.apple.screencapture "disable-shadow" -bool yes'),
-  shell("defaults write com.apple.screencapture name screenshot"),
-  shell("defaults write com.apple.screencapture location ~/screenshots/"),
-  shell("defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true"),
-  shell(`defaults write com.apple.controlstrip MiniCustomized '( "com.apple.system.brightness", "com.apple.system.volume", "com.apple.system.mute", "com.apple.system.sleep")'`),
-  shell("defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false"),
-  shell("defaults write com.microsoft.VSCodeInsiders ApplePressAndHoldEnabled -bool false"),
-  shell("defaults write com.lwouis.alt-tab-macos windowDisplayDelay 100"),
-  shell("defaults write com.apple.inputmethod.Kotoeri JIMPrefCharacterForYenKey 1"), // ことえり > ￥キーで入力する文字: \
-  shell("defaults write -g com.apple.mouse.tapBehavior -int 1"),
-  shell("defaults write -g com.apple.trackpad.scaling -int 3"),
-  shell("defaults write -g InitialKeyRepeat -int 15"),
-  shell("defaults write -g KeyRepeat -int 2"),
-  shell("defaults write -g AppleShowAllExtensions -bool true"),
-  shell("defaults write -g ApplePressAndHoldEnabled -bool false"),
-  shell("defaults write -g NSAutomaticSpellingCorrectionEnabled 1"), // 環境設定 > キーボード > ユーザ辞書 > 英字入力中にスペルを自動変換
-  shell('defaults write -g AppleInterfaceStyle -string "Dark"'), // Dark mode
+  defaults("com.apple.dock", "autohide", "-bool true", "1"),
+  defaults("com.apple.dock", "persistent-apps", "-array", "(\n)"),
+  defaults("com.apple.dock", "tilesize", "-int 55", "55"),
+  defaults("com.apple.finder", "AppleShowAllFiles", "-bool true", "1"),
+  defaults("com.apple.finder", "NewWindowTarget", "-string PfDe", "PfDe"),
+  defaults("com.apple.finder", "NewWindowTargetPath", `-string 'file://${home}/'`, `file://${home}/`),
+  defaults("com.apple.screencapture", "disable-shadow", "-bool true", "1"),
+  defaults("com.apple.screencapture", "name", "-string screenshot", "screenshot"),
+  defaults("com.apple.screencapture", "location", `-string '${home}/screenshots/'`, `${home}/screenshots/`),
+  defaults("com.apple.desktopservices", "DSDontWriteNetworkStores", "-bool true", "1"),
+  defaults("com.apple.controlstrip", "MiniCustomized",
+    "-array 'com.apple.system.brightness' 'com.apple.system.volume' 'com.apple.system.mute' 'com.apple.system.sleep'",
+    `(
+    "com.apple.system.brightness",
+    "com.apple.system.volume",
+    "com.apple.system.mute",
+    "com.apple.system.sleep"
+)`),
+  defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", "-bool false", "0"),
+  defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", "-bool false", "0"),
+  defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", "-int 100", "100"),
+  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1", "1"), // ことえり > ￥キーで入力する文字: \
+  defaults("-g", "com.apple.mouse.tapBehavior", "-int 1", "1"),
+  defaults("-g", "com.apple.trackpad.scaling", "-int 3", "3"),
+  defaults("-g", "InitialKeyRepeat", "-int 15", "15"),
+  defaults("-g", "KeyRepeat", "-int 2", "2"),
+  defaults("-g", "AppleShowAllExtensions", "-bool true", "1"),
+  defaults("-g", "ApplePressAndHoldEnabled", "-bool false", "0"),
+  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1", "1"), // 環境設定 > キーボード > ユーザ辞書 > 英字入力中にスペルを自動変換
+  defaults("-g", "AppleInterfaceStyle", "-string Dark", "Dark"), // Dark mode
   // vscode extension
   vscodeExtensions(`${home}/repos/github.com/ikenox/dotfiles/vscode/extensions.txt`),
   // install vim-plug


### PR DESCRIPTION
## Summary
- Refactor `Condition` return type from `boolean` to a discriminated union (`not-provisioned` / `already-provisioned` / `error`)
- Add dedicated `defaults` and `brewBundle` tasks with idempotency checks to skip when already provisioned
- Enhance `symlink` task to detect conflicts (non-symlink file or wrong link target) and report as error
- Continue execution on task failure and report all errors at the end

## Test plan
- [x] Run `node provisioner/src/main.ts --dry-run` and verify correct status labels for each task
- [x] Verify existing correct symlinks show `[OK]`
- [x] Verify conflicting files or wrong symlink targets show `[ERROR]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)