### PR TITLE
add --filter option to provisioner

### DIFF
--- a/provisioner/src/executor.ts
+++ b/provisioner/src/executor.ts
@@ -15,6 +15,7 @@ export const execute = async <const VarNames extends string[]>(
     args: process.argv.slice(2),
     options: {
       "dry-run": {type: "boolean", default: false},
+      "filter": {type: "string"},
     },
   });
 
@@ -34,6 +35,10 @@ export const execute = async <const VarNames extends string[]>(
 
   const errors: { name: string; message: string }[] = [];
   for (const task of tasks) {
+    if (args.filter && !task.name.includes(args.filter)) {
+      console.log(`${gray("[SKIP]")} ${task.name}`);
+      continue;
+    }
     const result = await task.condition();
     switch (result.status) {
       case "already-provisioned":


### PR DESCRIPTION
## Summary
- Add `--filter` option to run only tasks whose name contains the specified string
- Tasks not matching the filter are displayed as `[SKIP]` and skipped
- Usage: `node provisioner/src/main.ts --filter symlink`

## Test plan
- [ ] Verify `--filter symlink` runs only symlink-related tasks
- [ ] Verify running without `--filter` executes all tasks as before
- [ ] Verify `--dry-run --filter defaults` works correctly together

🤖 Generated with [Claude Code](https://claude.com/claude-code)