### PR TITLE
add project CLAUDE.md and update global Claude config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+## Overview
+
+A dotfiles repository for managing macOS development environment setup. Running `provision.sh` automates Homebrew package installation, symlink creation for config files, and macOS system preferences.
+
+## Structure
+
+- `provision.sh` — Entrypoint. Clones the repo, installs Homebrew and Node.js, then runs the provisioner
+- `provisioner/` — Provisioning tool written in Node.js (TypeScript). Task definitions are in `provisioner/src/main.ts`
+- `Brewfile` — List of packages to install via Homebrew
+- `claude/` — Global Claude Code settings (symlinked to `~/.claude/`)
+- Per-tool config directories (`git/`, `zsh/`, `vim/`, `ghostty/`, `karabiner/`, `vscode/`, `starship/`, `peco/`, `ag/`, `intellij/`, `jupyter/`, `qmk/`) — Configuration files for each tool

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -8,3 +8,4 @@
 ## Git
 
 - Do not use the `-C` option with git commands. Always `cd` into the target directory instead.
+- When writing commit messages, pull request descriptions, and code comments, match the natural language used in the repository (e.g., English or Japanese). Determine the appropriate language by checking the existing commit log.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` at repo root with project overview and directory structure
- Add rule to `claude/CLAUDE.md` for matching natural language in commits, PRs, and code comments to the repository's existing convention

## Test plan
- [ ] Verify `CLAUDE.md` accurately describes the repo structure
- [ ] Verify Claude Code picks up the new instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)