### PR TITLE
fix grammatical errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Execute provisioning
 
-### Initial execution from remote
+### Initial remote execution
 
 ```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/ikenox/dotfiles/master/provision.sh)"
 ```
 
-### Re-execution on local
+### Local re-execution
 
 ```sh
 ./provision.sh
@@ -19,22 +19,22 @@
 - Add "日本語" to 入力ソース
 - Settings > Keyboard > Shortcut
     - uncheck "select next input source by ^ + space".
-    - disable spotlight from keyboard shortcut
+    - Disable Spotlight keyboard shortcut
 - Settings > Keyboard > 辞書
     - Disable "スマート引用符とスマートダッシュを使用"
 - Set default browser to Chrome
-- Setup Touch ID
+- Set up Touch ID
 - Remove all icons from dock
 - Sign-in to app store
 - Migrate zsh history file from old machine
-- Add ssh public key to github
+- Add SSH public key to GitHub
 - Launch
     - alfred
     - karabiner-elements
     - alt-tab
 - Google Chrome: login & sync settings
 - Install Xcode
-    - Xcode command line tools will be installed when installing homebrew
+    - Xcode command line tools will be installed when installing Homebrew
     - xcode-select --install
 - Install intellij via toolbox
 - Configure alfred
@@ -48,4 +48,4 @@
 - 環境設定 > Bluetooth > Bluetoothをメニューバーに表示
 - Sign-in to slack with magic link
 - Restart MacOS
-    - Some changes by `defaults` command will be applied after restarting
+    - Some changes by the `defaults` command will be applied after restarting


### PR DESCRIPTION
## Summary
- Fix unnatural English expressions ("from remote", "on local", "from keyboard shortcut")
- Fix verb/noun confusion ("Setup" → "Set up")
- Capitalize proper nouns (SSH, GitHub, Homebrew, Spotlight)
- Add missing article ("the `defaults` command")

## Test plan
- [x] Review the diff to confirm only grammatical fixes, no content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)