### PR TITLE
automate manual tasks in provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,35 +17,19 @@
 ## Manual tasks
 
 - Add "日本語" to 入力ソース
-- Settings > Keyboard > Shortcut
-    - uncheck "select next input source by ^ + space".
-    - Disable Spotlight keyboard shortcut
-- Settings > Keyboard > 辞書
-    - Disable "スマート引用符とスマートダッシュを使用"
 - Set default browser to Chrome
 - Set up Touch ID
-- Remove all icons from dock
 - Sign-in to app store
 - Migrate zsh history file from old machine
 - Add SSH public key to GitHub
-- Launch
-    - alfred
-    - karabiner-elements
-    - alt-tab
 - Google Chrome: login & sync settings
-- Install Xcode
-    - Xcode command line tools will be installed when installing Homebrew
-    - xcode-select --install
-- Install intellij via toolbox
 - Configure alfred
     - Change hotkey -> ctrl + space
     - Change appearance to "Alfred Dark"
-- Exec vim `:PlugInstall`
 - Sync IntelliJ
   settings https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#IDE_settings_sync
     - login on JetBrains Toolbox
     - IntelliJ: login & "Sync Settings to JetBrains Account" > "Get Settings from Account"
-- 環境設定 > Bluetooth > Bluetoothをメニューバーに表示
 - Sign-in to slack with magic link
 - Restart MacOS
     - Some changes by the `defaults` command will be applied after restarting

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -33,16 +33,16 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
   symlink(`${home}/.dotfiles/vscode/keybindings.json`, `${home}/Library/Application Support/Code/User/keybindings.json`),
   symlink(`${home}/.dotfiles/vscode/tasks.json`, `${home}/Library/Application Support/Code/User/tasks.json`),
   // osx defaults
-  defaults("com.apple.dock", "autohide", "-bool true", "1"),
+  defaults("com.apple.dock", "autohide", "-bool true"),
   defaults("com.apple.dock", "persistent-apps", "-array", "(\n)"),
-  defaults("com.apple.dock", "tilesize", "-int 55", "55"),
-  defaults("com.apple.finder", "AppleShowAllFiles", "-bool true", "1"),
-  defaults("com.apple.finder", "NewWindowTarget", "-string PfDe", "PfDe"),
-  defaults("com.apple.finder", "NewWindowTargetPath", `-string 'file://${home}/'`, `file://${home}/`),
-  defaults("com.apple.screencapture", "disable-shadow", "-bool true", "1"),
-  defaults("com.apple.screencapture", "name", "-string screenshot", "screenshot"),
-  defaults("com.apple.screencapture", "location", `-string '${home}/screenshots/'`, `${home}/screenshots/`),
-  defaults("com.apple.desktopservices", "DSDontWriteNetworkStores", "-bool true", "1"),
+  defaults("com.apple.dock", "tilesize", "-int 55"),
+  defaults("com.apple.finder", "AppleShowAllFiles", "-bool true"),
+  defaults("com.apple.finder", "NewWindowTarget", "-string PfDe"),
+  defaults("com.apple.finder", "NewWindowTargetPath", `-string 'file://${home}/'`),
+  defaults("com.apple.screencapture", "disable-shadow", "-bool true"),
+  defaults("com.apple.screencapture", "name", "-string screenshot"),
+  defaults("com.apple.screencapture", "location", `-string '${home}/screenshots/'`),
+  defaults("com.apple.desktopservices", "DSDontWriteNetworkStores", "-bool true"),
   defaults("com.apple.controlstrip", "MiniCustomized",
     "-array 'com.apple.system.brightness' 'com.apple.system.volume' 'com.apple.system.mute' 'com.apple.system.sleep'",
     `(
@@ -51,21 +51,21 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
     "com.apple.system.mute",
     "com.apple.system.sleep"
 )`),
-  defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", "-bool false", "0"),
-  defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", "-bool false", "0"),
-  defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", "-int 100", "100"),
-  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1", "1"), // Kotoeri > Character for Yen key: \
-  defaults("-g", "com.apple.mouse.tapBehavior", "-int 1", "1"),
-  defaults("-g", "com.apple.trackpad.scaling", "-int 3", "3"),
-  defaults("-g", "InitialKeyRepeat", "-int 15", "15"),
-  defaults("-g", "KeyRepeat", "-int 2", "2"),
-  defaults("-g", "AppleShowAllExtensions", "-bool true", "1"),
-  defaults("-g", "ApplePressAndHoldEnabled", "-bool false", "0"),
-  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1", "1"), // Keyboard > Text Replacements > Correct spelling automatically
-  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", "-bool false", "0"), // Keyboard > Text Replacements > Use smart quotes
-  defaults("-g", "NSAutomaticDashSubstitutionEnabled", "-bool false", "0"), // Keyboard > Text Replacements > Use smart dashes
-  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "-bool true", "1"), // Show Bluetooth in menu bar
-  defaults("-g", "AppleInterfaceStyle", "-string Dark", "Dark"), // Dark mode
+  defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", "-bool false"),
+  defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", "-bool false"),
+  defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", "-int 100"),
+  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1"), // Kotoeri > Character for Yen key: \
+  defaults("-g", "com.apple.mouse.tapBehavior", "-int 1"),
+  defaults("-g", "com.apple.trackpad.scaling", "-int 3"),
+  defaults("-g", "InitialKeyRepeat", "-int 15"),
+  defaults("-g", "KeyRepeat", "-int 2"),
+  defaults("-g", "AppleShowAllExtensions", "-bool true"),
+  defaults("-g", "ApplePressAndHoldEnabled", "-bool false"),
+  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1"), // Keyboard > Text Replacements > Correct spelling automatically
+  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", "-bool false"), // Keyboard > Text Replacements > Use smart quotes
+  defaults("-g", "NSAutomaticDashSubstitutionEnabled", "-bool false"), // Keyboard > Text Replacements > Use smart dashes
+  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "-bool true"), // Show Bluetooth in menu bar
+  defaults("-g", "AppleInterfaceStyle", "-string Dark"), // Dark mode
   // Keyboard > Shortcuts > Input Sources > Disable "Select next input source" (^ + Space)
   defaultsDictAdd(
     "com.apple.symbolichotkeys", "AppleSymbolicHotKeys", "60",

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -33,39 +33,40 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
   symlink(`${home}/.dotfiles/vscode/keybindings.json`, `${home}/Library/Application Support/Code/User/keybindings.json`),
   symlink(`${home}/.dotfiles/vscode/tasks.json`, `${home}/Library/Application Support/Code/User/tasks.json`),
   // osx defaults
-  defaults("com.apple.dock", "autohide", "-bool true"),
-  defaults("com.apple.dock", "persistent-apps", "-array", "(\n)"),
-  defaults("com.apple.dock", "tilesize", "-int 55"),
-  defaults("com.apple.finder", "AppleShowAllFiles", "-bool true"),
-  defaults("com.apple.finder", "NewWindowTarget", "-string PfDe"),
-  defaults("com.apple.finder", "NewWindowTargetPath", `-string 'file://${home}/'`),
-  defaults("com.apple.screencapture", "disable-shadow", "-bool true"),
-  defaults("com.apple.screencapture", "name", "-string screenshot"),
-  defaults("com.apple.screencapture", "location", `-string '${home}/screenshots/'`),
-  defaults("com.apple.desktopservices", "DSDontWriteNetworkStores", "-bool true"),
-  defaults("com.apple.controlstrip", "MiniCustomized",
-    "-array 'com.apple.system.brightness' 'com.apple.system.volume' 'com.apple.system.mute' 'com.apple.system.sleep'",
-    `(
+  defaults("com.apple.dock", "autohide", {bool: true}),
+  defaults("com.apple.dock", "persistent-apps", {array: "", expected: "(\n)"}),
+  defaults("com.apple.dock", "tilesize", {int: 55}),
+  defaults("com.apple.finder", "AppleShowAllFiles", {bool: true}),
+  defaults("com.apple.finder", "NewWindowTarget", {string: "PfDe"}),
+  defaults("com.apple.finder", "NewWindowTargetPath", {string: `file://${home}/`}),
+  defaults("com.apple.screencapture", "disable-shadow", {bool: true}),
+  defaults("com.apple.screencapture", "name", {string: "screenshot"}),
+  defaults("com.apple.screencapture", "location", {string: `${home}/screenshots/`}),
+  defaults("com.apple.desktopservices", "DSDontWriteNetworkStores", {bool: true}),
+  defaults("com.apple.controlstrip", "MiniCustomized", {
+    array: "'com.apple.system.brightness' 'com.apple.system.volume' 'com.apple.system.mute' 'com.apple.system.sleep'",
+    expected: `(
     "com.apple.system.brightness",
     "com.apple.system.volume",
     "com.apple.system.mute",
     "com.apple.system.sleep"
-)`),
-  defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", "-bool false"),
-  defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", "-bool false"),
-  defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", "-int 100"),
-  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1"), // Kotoeri > Character for Yen key: \
-  defaults("-g", "com.apple.mouse.tapBehavior", "-int 1"),
-  defaults("-g", "com.apple.trackpad.scaling", "-int 3"),
-  defaults("-g", "InitialKeyRepeat", "-int 15"),
-  defaults("-g", "KeyRepeat", "-int 2"),
-  defaults("-g", "AppleShowAllExtensions", "-bool true"),
-  defaults("-g", "ApplePressAndHoldEnabled", "-bool false"),
-  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1"), // Keyboard > Text Replacements > Correct spelling automatically
-  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", "-bool false"), // Keyboard > Text Replacements > Use smart quotes
-  defaults("-g", "NSAutomaticDashSubstitutionEnabled", "-bool false"), // Keyboard > Text Replacements > Use smart dashes
-  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "-bool true"), // Show Bluetooth in menu bar
-  defaults("-g", "AppleInterfaceStyle", "-string Dark"), // Dark mode
+)`,
+  }),
+  defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", {bool: false}),
+  defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", {bool: false}),
+  defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", {int: 100}),
+  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", {int: 1}), // Kotoeri > Character for Yen key: \
+  defaults("-g", "com.apple.mouse.tapBehavior", {int: 1}),
+  defaults("-g", "com.apple.trackpad.scaling", {int: 3}),
+  defaults("-g", "InitialKeyRepeat", {int: 15}),
+  defaults("-g", "KeyRepeat", {int: 2}),
+  defaults("-g", "AppleShowAllExtensions", {bool: true}),
+  defaults("-g", "ApplePressAndHoldEnabled", {bool: false}),
+  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", {int: 1}), // Keyboard > Text Replacements > Correct spelling automatically
+  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", {bool: false}), // Keyboard > Text Replacements > Use smart quotes
+  defaults("-g", "NSAutomaticDashSubstitutionEnabled", {bool: false}), // Keyboard > Text Replacements > Use smart dashes
+  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", {bool: true}), // Show Bluetooth in menu bar
+  defaults("-g", "AppleInterfaceStyle", {string: "Dark"}), // Dark mode
   // Keyboard > Shortcuts > Input Sources > Disable "Select next input source" (^ + Space)
   defaultsDictAdd(
     "com.apple.symbolichotkeys", "AppleSymbolicHotKeys", "60",

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -93,6 +93,6 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
   }),
   // launch apps
   shell("open -a 'Alfred 5'", {condition: ifNotRunning("Alfred")}),
-  shell("open -a 'Karabiner-Elements'", {condition: ifNotRunning("karabiner_grabber")}),
+  shell("open -a 'Karabiner-Elements'", {condition: ifNotRunning("karabiner")}),
   shell("open -a 'AltTab'", {condition: ifNotRunning("AltTab")}),
 ])

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -54,29 +54,27 @@ void execute(['username', 'email'], ({username, email}, {home}) => [
   defaults("com.microsoft.VSCode", "ApplePressAndHoldEnabled", "-bool false", "0"),
   defaults("com.microsoft.VSCodeInsiders", "ApplePressAndHoldEnabled", "-bool false", "0"),
   defaults("com.lwouis.alt-tab-macos", "windowDisplayDelay", "-int 100", "100"),
-  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1", "1"), // ことえり > ￥キーで入力する文字: \
+  defaults("com.apple.inputmethod.Kotoeri", "JIMPrefCharacterForYenKey", "-int 1", "1"), // Kotoeri > Character for Yen key: \
   defaults("-g", "com.apple.mouse.tapBehavior", "-int 1", "1"),
   defaults("-g", "com.apple.trackpad.scaling", "-int 3", "3"),
   defaults("-g", "InitialKeyRepeat", "-int 15", "15"),
   defaults("-g", "KeyRepeat", "-int 2", "2"),
   defaults("-g", "AppleShowAllExtensions", "-bool true", "1"),
   defaults("-g", "ApplePressAndHoldEnabled", "-bool false", "0"),
-  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1", "1"), // 環境設定 > キーボード > ユーザ辞書 > 英字入力中にスペルを自動変換
-  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", "-bool false", "0"),
-  defaults("-g", "NSAutomaticDashSubstitutionEnabled", "-bool false", "0"),
-  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "-bool true", "1"),
+  defaults("-g", "NSAutomaticSpellingCorrectionEnabled", "-int 1", "1"), // Keyboard > Text Replacements > Correct spelling automatically
+  defaults("-g", "NSAutomaticQuoteSubstitutionEnabled", "-bool false", "0"), // Keyboard > Text Replacements > Use smart quotes
+  defaults("-g", "NSAutomaticDashSubstitutionEnabled", "-bool false", "0"), // Keyboard > Text Replacements > Use smart dashes
+  defaults("com.apple.controlcenter", "NSStatusItem Visible Bluetooth", "-bool true", "1"), // Show Bluetooth in menu bar
   defaults("-g", "AppleInterfaceStyle", "-string Dark", "Dark"), // Dark mode
-  // disable ^ + Space input source switching
+  // Keyboard > Shortcuts > Input Sources > Disable "Select next input source" (^ + Space)
   defaultsDictAdd(
     "com.apple.symbolichotkeys", "AppleSymbolicHotKeys", "60",
     '<dict><key>enabled</key><false/><key>value</key><dict><key>parameters</key><array><integer>32</integer><integer>49</integer><integer>262144</integer></array><key>type</key><string>standard</string></dict></dict>',
-    (stdout) => /60\s*=\s*\{\s*enabled\s*=\s*0/.test(stdout),
   ),
-  // disable Spotlight shortcut
+  // Keyboard > Shortcuts > Spotlight > Disable "Show Spotlight search"
   defaultsDictAdd(
     "com.apple.symbolichotkeys", "AppleSymbolicHotKeys", "64",
     '<dict><key>enabled</key><false/><key>value</key><dict><key>parameters</key><array><integer>32</integer><integer>49</integer><integer>1048576</integer></array><key>type</key><string>standard</string></dict></dict>',
-    (stdout) => /64\s*=\s*\{\s*enabled\s*=\s*0/.test(stdout),
   ),
   // vscode extension
   vscodeExtensions(`${home}/repos/github.com/ikenox/dotfiles/vscode/extensions.txt`),

--- a/provisioner/src/task.ts
+++ b/provisioner/src/task.ts
@@ -66,10 +66,10 @@ export const symlink = (src: string, dest: string): Task => {
 export const defaults = (domain: string, key: string, writeArgs: string, expected: string): Task => ({
   name: `defaults ${domain} ${key}`,
   condition: async (): Promise<ConditionResult> => {
-    const {stdout} = await getResult(`defaults read ${domain} ${key}`);
+    const {stdout} = await getResult(`defaults read ${domain} '${key}'`);
     return stdout === expected ? {status: "already-provisioned"} : {status: "not-provisioned"};
   },
-  execute: run(`defaults write ${domain} ${key} ${writeArgs}`),
+  execute: run(`defaults write ${domain} '${key}' ${writeArgs}`),
 });
 
 export const brewBundle = (): Task => ({
@@ -126,12 +126,12 @@ export const defaultsDictAdd = (
   key: string,
   dictKey: string,
   plistValue: string,
-  conditionCheck: (stdout: string) => boolean,
 ): Task => ({
   name: `defaults dict-add ${domain} ${key} ${dictKey}`,
   condition: async (): Promise<ConditionResult> => {
     const {stdout} = await getResult(`defaults read ${domain} ${key}`);
-    return conditionCheck(stdout) ? {status: "already-provisioned"} : {status: "not-provisioned"};
+    const pattern = new RegExp(`${dictKey}\\s*=\\s*\\{\\s*enabled\\s*=\\s*0`);
+    return pattern.test(stdout) ? {status: "already-provisioned"} : {status: "not-provisioned"};
   },
   execute: run(`defaults write ${domain} ${key} -dict-add ${dictKey} '${plistValue}'`),
 });

--- a/provisioner/src/task.ts
+++ b/provisioner/src/task.ts
@@ -91,7 +91,7 @@ const toDefaultsArgs = (value: DefaultsValue): { writeArgs: string; expected: st
 export const brewBundle = (): Task => ({
   name: "brew bundle",
   condition: async (): Promise<ConditionResult> => {
-    const {success} = await getResult("brew bundle check");
+    const {success} = await getResult("brew bundle check --no-upgrade");
     return success ? {status: "already-provisioned"} : {status: "not-provisioned"};
   },
   execute: run("brew bundle --no-upgrade"),

--- a/provisioner/src/task.ts
+++ b/provisioner/src/task.ts
@@ -156,7 +156,7 @@ export const ifNotExists = (file: string): Condition => () =>
     exists(file).then((e): ConditionResult => e ? {status: "already-provisioned"} : {status: "not-provisioned"});
 
 export const ifNotRunning = (processName: string): Condition => async () => {
-  const {success} = await getResult(`pgrep -x '${processName}'`);
+  const {success} = await getResult(`pgrep '${processName}'`);
   return success ? {status: "already-provisioned"} : {status: "not-provisioned"};
 };
 


### PR DESCRIPTION
## Summary
- Add `defaultsDictAdd` and `ifNotRunning` task helpers to `provisioner/src/task.ts`
- Automate previously manual tasks: smart quotes/dashes, keyboard shortcut disabling (^ + Space, Spotlight), Bluetooth menu bar, vim `:PlugInstall`, app launches (Alfred, Karabiner-Elements, AltTab)
- Remove already-covered items from README manual tasks list (dock icons, Xcode CLI tools, IntelliJ via Toolbox)

## Test plan
- [x] `node src/main.ts --dry-run` completes without errors
- [x] Run provisioner on a fresh or existing machine and verify new tasks execute correctly
- [x] Verify `--filter` works for individual new tasks (e.g. `--filter "dict-add"`, `--filter "PlugInstall"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)