### PR TITLE
worktree作成をdefault branchにいる場合のみに限定

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -2,8 +2,8 @@
 
 **IMPORTANT: Before making ANY file changes, you MUST complete step 1. No exceptions, even for small or single-file changes.**
 
-1. Create a branch and worktree: fetch the latest remote default branch (`git fetch origin $DEFAULT_BRANCH`), then create a new branch from `origin/$DEFAULT_BRANCH` and a git worktree for it under `.worktree/`, and `cd` into it so that all subsequent commands run inside the worktree. Choose an appropriate branch/worktree name based on the task description. Do not commit directly to main. Unless the user explicitly instructs otherwise (e.g., working on an existing branch, or skipping worktree creation), always follow this step.
-2. Make your changes in the worktree.
+1. If the current branch is the default branch (e.g., main or master), create a branch and worktree: fetch the latest remote default branch (`git fetch origin $DEFAULT_BRANCH`), then create a new branch from `origin/$DEFAULT_BRANCH` and a git worktree for it under `.worktree/`, and `cd` into it so that all subsequent commands run inside the worktree. Choose an appropriate branch/worktree name based on the task description. Do not commit directly to the default branch. Unless the user explicitly instructs otherwise (e.g., skipping worktree creation), always follow this step. If already on a non-default branch, skip worktree creation and work directly on the current branch.
+2. Make your changes.
 
 ## Git
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdのワークフロー指示を変更し、worktreeの作成を現在のブランチがdefault branch（main/master）の場合のみに限定
- 既にfeature branchにいる場合はworktree作成をスキップし、そのブランチで直接作業するよう指示を更新

## Test plan
- [ ] default branch上でClaude Codeにファイル変更を依頼し、worktreeが作成されることを確認
- [ ] feature branch上でClaude Codeにファイル変更を依頼し、worktree作成がスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)