### PR TITLE
emphasize natural language matching rule in CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -8,4 +8,4 @@
 ## Git
 
 - Do not use the `-C` option with git commands. Always `cd` into the target directory instead.
-- When writing commit messages, pull request descriptions, and code comments, match the natural language used in the repository (e.g., English or Japanese). Determine the appropriate language by checking the existing commit log.
+- **IMPORTANT: When writing commit messages, pull request descriptions, and code comments, you MUST match the natural language used in the repository. Before writing any commit message or PR description, ALWAYS run `git log --oneline -10` first to check the language (e.g., English or Japanese) used in recent commits, and write in that same language. This is a strict requirement — do NOT default to English without checking.**


### PR DESCRIPTION
## Summary
- Make the commit message / PR description language rule more prominent so it is consistently followed
- Add `IMPORTANT` and `MUST` markers, and explicit instruction to run `git log --oneline -10` before writing commit messages or PR descriptions
- Explicitly prohibit defaulting to English without checking

## Test plan
- [ ] Verify the updated `claude/CLAUDE.md` renders correctly
- [ ] Confirm Claude Code follows the emphasized instruction in subsequent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)