### PR TITLE
Improve natural language matching rule in CLAUDE.md

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -7,5 +7,10 @@
 
 ## Git
 
+- **IMPORTANT — Natural language rule for git output (commit messages, PR titles, PR descriptions, code comments):**
+  1. Before writing ANY commit message or PR description, ALWAYS run `git log --oneline -10` first.
+  2. Determine the language used in those commit messages (e.g., English or Japanese).
+  3. Write your commit message, PR title, PR description, and code comments in **that same language**.
+  4. **The language of the user's conversation prompt is IRRELEVANT. Even if the user writes in Japanese, if the git log is in English, you MUST write in English. Even if the user writes in English, if the git log is in Japanese, you MUST write in Japanese. The ONLY source of truth is the git log.**
+  5. Double-check before finalizing: re-read your draft and confirm it matches the git log language. If it doesn't, rewrite it.
 - Do not use the `-C` option with git commands. Always `cd` into the target directory instead.
-- **IMPORTANT: When writing commit messages, pull request descriptions, and code comments, you MUST match the natural language used in the repository. Before writing any commit message or PR description, ALWAYS run `git log --oneline -10` first to check the language (e.g., English or Japanese) used in recent commits, and write in that same language. The language used in the conversation prompt MUST be completely ignored — only the git log matters. This is a strict requirement — do NOT default to English without checking.**


### PR DESCRIPTION
## Summary
- Restructured the natural language rule into numbered steps for clarity
- Added explicit examples showing conversation language must be ignored (e.g., Japanese prompt + English git log → write in English)
- Added a double-check step to catch language mismatches before finalizing

## Test plan
- [ ] Verify that commit messages and PR descriptions are written in the git log language, not the conversation language

🤖 Generated with [Claude Code](https://claude.com/claude-code)