### PR TITLE
make notification clickable to activate Ghostty

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ brew "docker"
 brew "im-select"
 brew "expect"
 brew "node"
+brew "terminal-notifier"
 
 cask "karabiner-elements"
 cask "ghostty"

--- a/claude/hooks/notification.sh
+++ b/claude/hooks/notification.sh
@@ -19,6 +19,15 @@ case "$NOTIFICATION_TYPE" in
 esac
 
 afplay "$SOUND_MAC" 2>/dev/null &
-osascript -e "display notification \"$MESSAGE\" with title \"Claude Code\"" 2>/dev/null &
+
+if command -v terminal-notifier >/dev/null 2>&1; then
+    terminal-notifier \
+        -title "Claude Code" \
+        -message "$MESSAGE" \
+        -activate "com.mitchellh.ghostty" \
+        >/dev/null 2>&1 &
+else
+    osascript -e "display notification \"$MESSAGE\" with title \"Claude Code\"" 2>/dev/null &
+fi
 
 exit 0


### PR DESCRIPTION
Use terminal-notifier when available so clicking the notification brings Ghostty to the foreground. Falls back to osascript otherwise.