### PR TITLE
fix and refine Zed vim keybindings

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -42,6 +42,10 @@
       "g n": "editor::FindNextMatch",            // NextOccurence
       "g p": "editor::FindPreviousMatch",        // PreviousOccurence
 
+      // vimrc.keymap: ; <-> : swap
+      ";": ["workspace::SendKeystrokes", ":"],
+      ":": "vim::RepeatFind",
+
       // ideavimrc: code editing
       "r": "editor::Rename",                     // RenameElement
       "q": "editor::ToggleCodeActions",          // ShowIntentionActions
@@ -63,6 +67,8 @@
     "bindings": {
       "shift-l": ["workspace::SendKeystrokes", "$"],
       "shift-h": ["workspace::SendKeystrokes", "^"],
+      ";": ["workspace::SendKeystrokes", ":"],
+      ":": "vim::RepeatFind",
       "= =": "editor::Format",
       // cc removed: conflicts with vim's c operator (use gc<motion> instead)
       // ideavimrc: p -> EditorSelectWord (expand), n -> EditorUnSelectWord (shrink)

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -42,9 +42,8 @@
       "g n": "editor::FindNextMatch",            // NextOccurence
       "g p": "editor::FindPreviousMatch",        // PreviousOccurence
 
-      // vimrc.keymap: ; <-> : swap
+      // vimrc.keymap: ; -> : (so ;w saves, ;e opens, etc.)
       ";": ["workspace::SendKeystrokes", ":"],
-      ":": "vim::RepeatFind",
 
       // ideavimrc: code editing
       "r": "editor::Rename",                     // RenameElement
@@ -68,7 +67,6 @@
       "shift-l": ["workspace::SendKeystrokes", "$"],
       "shift-h": ["workspace::SendKeystrokes", "^"],
       ";": ["workspace::SendKeystrokes", ":"],
-      ":": "vim::RepeatFind",
       "= =": "editor::Format",
       // cc removed: conflicts with vim's c operator (use gc<motion> instead)
       // ideavimrc: p -> EditorSelectWord (expand), n -> EditorUnSelectWord (shrink)

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -1,5 +1,6 @@
 // Zed Key Bindings
 // Ported from ideavimrc + vimrc.keymap
+// $schema: zed://schemas/keymaps
 [
   {
     "context": "Editor && vim_mode == normal && !menu",
@@ -45,7 +46,7 @@
       "r": "editor::Rename",                     // RenameElement
       "q": "editor::ToggleCodeActions",          // ShowIntentionActions
       "= =": "editor::Format",                   // ReformatCode
-      "c c": "editor::ToggleComments",           // CommentByLineComment
+      // cc removed: conflicts with vim's c operator (use gcc / gc<motion> instead)
       "ctrl-i": "editor::Hover",                 // QuickJavaDoc
 
       // ideavimrc: bookmarks/breakpoints
@@ -63,7 +64,7 @@
       "shift-l": ["workspace::SendKeystrokes", "$"],
       "shift-h": ["workspace::SendKeystrokes", "^"],
       "= =": "editor::Format",
-      "c c": "editor::ToggleComments",
+      // cc removed: conflicts with vim's c operator (use gc<motion> instead)
       // ideavimrc: p -> EditorSelectWord (expand), n -> EditorUnSelectWord (shrink)
       "p": "editor::SelectLargerSyntaxNode",
       "n": "editor::SelectSmallerSyntaxNode",

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -79,7 +79,7 @@
   {
     "context": "Pane",
     "bindings": {
-      "cmd-ctrl-g": "pane::ActivateNextItem",
+      "cmd-ctrl-l": "pane::ActivateNextItem",
       "cmd-ctrl-h": "pane::ActivatePreviousItem"
     }
   },

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -77,6 +77,13 @@
     }
   },
   {
+    "context": "Pane",
+    "bindings": {
+      "cmd-ctrl-g": "pane::ActivateNextItem",
+      "cmd-ctrl-h": "pane::ActivatePreviousItem"
+    }
+  },
+  {
     "context": "Editor && vim_mode == insert",
     "bindings": {
       // vimrc.keymap: jf -> <ESC>

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -13,48 +13,48 @@
       "g l": "pane::GoForward",
 
       // vimrc.keymap: s-prefix window/pane management
-      "s h": ["workspace::ActivatePaneInDirection", "Left"],
-      "s j": ["workspace::ActivatePaneInDirection", "Down"],
-      "s k": ["workspace::ActivatePaneInDirection", "Up"],
-      "s l": ["workspace::ActivatePaneInDirection", "Right"],
+      "s h": "workspace::ActivatePaneLeft",
+      "s j": "workspace::ActivatePaneDown",
+      "s k": "workspace::ActivatePaneUp",
+      "s l": "workspace::ActivatePaneRight",
       "s s": "pane::SplitDown",
       "s v": "pane::SplitRight",
       "s n": "pane::ActivateNextItem",
-      "s p": "pane::ActivatePrevItem",
+      "s p": "pane::ActivatePreviousItem",
       "s ;": "pane::CloseActiveItem",
 
       // ideavimrc: , (leader) bindings
-      ", a": "command_palette::Toggle",      // GotoAction
+      ", a": "command_palette::Toggle",          // GotoAction
       ", e": "project_symbols::Toggle",          // SearchEverywhere (symbol/class name search)
-      ", s": "outline::Toggle",               // FileStructurePopup
-      ", g": "workspace::NewSearch",          // FindInPath
-      ", r": "recent_files::Toggle",          // RecentFiles
-      ", f": "file_finder::Toggle",           // GotoFile
-      ", z": "workspace::OpenRecent",         // RecentProjectListGroup
+      ", s": "outline::Toggle",                  // FileStructurePopup
+      ", g": "workspace::NewSearch",             // FindInPath
+      ", r": "file_finder::Toggle",              // RecentFiles (no direct equivalent)
+      ", f": "file_finder::Toggle",              // GotoFile
+      ", z": "projects::OpenRecent",             // RecentProjectListGroup
 
       // ideavimrc: code navigation
-      "g d": "editor::GoToDefinition",        // GotoDeclaration
-      "g i": "editor::GoToImplementation",    // GotoImplementation
-      "g u": "editor::FindAllReferences",     // ShowUsages
-      "g shift-u": "editor::FindAllReferences", // FindUsages
-      "g f": "file_finder::Toggle",           // GotoFile
-      "g n": "editor::SelectNextMatch",       // NextOccurence
-      "g p": "editor::SelectPreviousMatch",   // PreviousOccurence
+      "g d": "editor::GoToDefinition",           // GotoDeclaration
+      "g i": "editor::GoToImplementation",       // GotoImplementation
+      "g u": "editor::FindAllReferences",        // ShowUsages
+      "g shift-u": "editor::FindAllReferences",  // FindUsages
+      "g f": "file_finder::Toggle",              // GotoFile
+      "g n": "editor::FindNextMatch",            // NextOccurence
+      "g p": "editor::FindPreviousMatch",        // PreviousOccurence
 
       // ideavimrc: code editing
-      "r": "editor::Rename",                  // RenameElement
-      "q": "editor::ToggleCodeActions",       // ShowIntentionActions
-      "= =": "editor::Format",                // ReformatCode (overrides indent current line)
-      "c c": "editor::ToggleComments",        // CommentByLineComment (overrides change line)
-      "ctrl-i": "editor::Hover",              // QuickJavaDoc
+      "r": "editor::Rename",                     // RenameElement
+      "q": "editor::ToggleCodeActions",          // ShowIntentionActions
+      "= =": "editor::Format",                   // ReformatCode
+      "c c": "editor::ToggleComments",           // CommentByLineComment
+      "ctrl-i": "editor::Hover",                 // QuickJavaDoc
 
       // ideavimrc: bookmarks/breakpoints
-      "shift-b": "editor::ToggleBreakpoint",  // ToggleBookmark (closest equivalent)
+      "shift-b": "editor::ToggleBreakpoint",     // ToggleBookmark (closest equivalent)
 
       // ideavimrc: run / debug
-      "shift-r": "tasks::Spawn",              // ChooseRunConfiguration
-      "-": "debugger::StepOver",              // StepOver
-      "_": "debugger::Continue"               // Resume
+      "shift-r": "task::Spawn",                  // ChooseRunConfiguration
+      "-": "debugger::StepOver",                 // StepOver
+      "_": "debugger::Continue"                  // Resume
     }
   },
   {

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -18,6 +18,7 @@
   },
   "base_keymap": "JetBrains",
   "ui_font_size": 14,
+  "ui_font_family": "JetBrains Mono",
   "buffer_font_size": 14,
   "buffer_font_family": "JetBrains Mono",
   "theme": {

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -17,8 +17,9 @@
     "use_system_clipboard": "always"
   },
   "base_keymap": "JetBrains",
-  "ui_font_size": 16,
-  "buffer_font_size": 15,
+  "ui_font_size": 14,
+  "buffer_font_size": 14,
+  "buffer_font_family": "JetBrains Mono",
   "theme": {
     "mode": "system",
     "light": "One Light",

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,25 +1,17 @@
-// Zed settings
-//
-// For information on how to configure Zed, see the Zed
-// documentation: https://zed.dev/docs/configuring-zed
-//
-// To see all of Zed's default settings without changing your
-// custom settings, run `zed: open default settings` from the
-// command palette (cmd-shift-p / ctrl-shift-p)
 {
+  "$schema": "zed://schemas/settings",
   "telemetry": {
     "diagnostics": false,
     "metrics": false
   },
   "vim_mode": true,
   "vim": {
-    // set clipboard=unnamed,autoselect
     "use_system_clipboard": "always"
   },
   "base_keymap": "JetBrains",
   "ui_font_size": 14,
   "ui_font_family": "JetBrains Mono",
-  "buffer_font_size": 14,
+  "buffer_font_size": 12,
   "buffer_font_family": "JetBrains Mono",
   "theme": {
     "mode": "system",


### PR DESCRIPTION
## Summary
- Fix broken `vim` settings block in settings.json and add JSON schema
- Fix incorrect action names in keymap.json (pane direction, task spawn, etc.)
- Set JetBrains Mono as UI and buffer font
- Remove `cc` binding that conflicted with vim's change operator (use `gcc` instead)
- Add `;` → `:` mapping for ex commands (e.g. `;w` to save)
- Add `cmd+ctrl+l/h` shortcuts for tab navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)