### PR TITLE
Add deno-script skill for sandboxed ad-hoc scripting

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -17,6 +17,7 @@ brew "im-select"
 brew "expect"
 brew "node"
 brew "oven-sh/bun/bun"
+brew "deno"
 brew "terminal-notifier"
 
 cask "karabiner-elements"

--- a/claude/hooks/block-adhoc-scripts.sh
+++ b/claude/hooks/block-adhoc-scripts.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Block ad-hoc Python/Perl/Node/Ruby script execution.
+# Rationale: each invocation triggers a permission prompt and bypasses the
+# deno sandbox wrapper. Steer Claude toward the deno-script skill instead.
+#
+# Blocks:
+#   - inline eval flags: `python -c`, `perl -e`, `node -e`, `ruby -e`, `bun -e`
+#   - direct interpreter-file invocation: `python foo.py`, `perl foo.pl`,
+#     `ruby foo.rb`, `node foo.js` / `.mjs` / `.cjs` / `.ts`
+#
+# Does NOT block: npm, npx, pytest, bun run, bun install, package managers, etc.
+
+CMD=$(jq -r '.tool_input.command')
+
+MSG='Ad-hoc Python/Perl/Node/Ruby scripting is disabled. Use the deno-script skill instead: ~/.claude/skills/deno-script/scripts/run.sh <script.ts>'
+
+# Inline eval (-e / -c)
+if echo "$CMD" | grep -qE '(^|[[:space:];|&])(python3?|perl|node|ruby|bun)([[:space:]]+-[a-zA-Z]*)*[[:space:]]+-(e|c)([[:space:]]|$)'; then
+  echo "$MSG" >&2
+  exit 2
+fi
+
+# Direct script-file execution
+if echo "$CMD" | grep -qE '(^|[[:space:];|&])(python3?|perl|ruby)[[:space:]]+[^-[:space:]][^[:space:]]*\.(py|pl|rb)([[:space:]]|$)'; then
+  echo "$MSG" >&2
+  exit 2
+fi
+
+if echo "$CMD" | grep -qE '(^|[[:space:];|&])node[[:space:]]+[^-[:space:]][^[:space:]]*\.(js|mjs|cjs|ts)([[:space:]]|$)'; then
+  echo "$MSG" >&2
+  exit 2
+fi
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -45,10 +45,7 @@
       "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/fetch_unresolved_threads.sh *)",
       "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/reply_to_thread.sh *)",
       "Bash(/Users/ikenonaoto/.claude/skills/deno-script/scripts/run.sh *)",
-      "Bash(~/.claude/skills/deno-script/scripts/run.sh *)",
-      "Bash(deno cache *)",
-      "Bash(deno fmt *)",
-      "Bash(deno check *)"
+      "Bash(~/.claude/skills/deno-script/scripts/run.sh *)"
     ],
     "deny": []
   },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -42,6 +42,7 @@
       "Bash(file *)",
       "Bash(tree *)",
       "Bash(stat *)",
+      "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/fetch_unresolved_threads.sh *)",
       "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/reply_to_thread.sh *)"
     ],
     "deny": []

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -43,7 +43,12 @@
       "Bash(tree *)",
       "Bash(stat *)",
       "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/fetch_unresolved_threads.sh *)",
-      "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/reply_to_thread.sh *)"
+      "Bash(/Users/ikenonaoto/.claude/skills/address-reviews/scripts/reply_to_thread.sh *)",
+      "Bash(/Users/ikenonaoto/.claude/skills/deno-script/scripts/run.sh *)",
+      "Bash(~/.claude/skills/deno-script/scripts/run.sh *)",
+      "Bash(deno cache *)",
+      "Bash(deno fmt *)",
+      "Bash(deno check *)"
     ],
     "deny": []
   },
@@ -55,6 +60,10 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/block-git-c.sh"
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-adhoc-scripts.sh"
           }
         ]
       }

--- a/claude/skills/deno-script/SKILL.md
+++ b/claude/skills/deno-script/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: deno-script
+description: Run ad-hoc local data-processing scripts via Deno's sandbox instead of writing Python/Perl/Node one-liners. Use this skill whenever you need a throwaway script to transform files, parse/reshape data, do text/JSON/CSV munging, bulk-rename files, compute statistics, or any other non-trivial local computation that feels too involved for plain shell pipelines. The sandbox wrapper runs scripts with filesystem-only permissions (no network, no subprocess, no FFI, no env access), so it's pre-approved in settings — users don't get a permission prompt per run. Prefer this over `python -c`, `perl -e`, `node -e`, `ruby -e`, or writing throwaway `.py`/`.js` files (those are blocked by a hook anyway).
+---
+
+# deno-script
+
+Ad-hoc scripting runner using Deno's capability-based sandbox. The goal: when you need a real programming language for a task (not just shell), reach for this instead of Python/Node/Perl — it's pre-approved and automatically sandboxed to filesystem-only.
+
+## Why this exists
+
+Writing throwaway Python/Node scripts forces the user to approve each Bash invocation. Deno with `--allow-read --allow-write` and nothing else gives us:
+
+- No network access (can't exfiltrate)
+- No subprocess spawning (can't escape via `Deno.Command`)
+- No FFI, no env var reads, no system info
+- Filesystem is the only side channel, and the user's machine is already trusted to run local code
+
+That's safe enough that the wrapper is pre-approved in `settings.json`, so no permission prompt.
+
+## How to use
+
+1. Write a TypeScript file somewhere under `.claude/tmp/` (per user's temp-file rule). Use `.ts` extension.
+2. Run it via the wrapper:
+
+```bash
+~/.claude/skills/deno-script/scripts/run.sh .claude/tmp/my-script.ts [args...]
+```
+
+The wrapper enforces the sandbox — you cannot override its flags. Anything after the script path is passed through as script args (`Deno.args`).
+
+## What's available inside the script
+
+- Full Deno std library (import via `jsr:` or `https://deno.land/std`) — **but only cached modules**, since network is disabled. First-run imports will fail; prefetch with `deno cache <script>` if needed (that's a separate, allowed step).
+- `Deno.readTextFile`, `Deno.writeTextFile`, `Deno.readDir`, file globbing via std, etc.
+- Plain TypeScript — no transpile step needed.
+
+## What's NOT available
+
+- `fetch` / network anything
+- `Deno.Command` / subprocess
+- `Deno.env`
+- FFI
+
+If you actually need one of these, don't try to work around the sandbox — tell the user and ask them to run it manually or add a narrower permission.
+
+## Example
+
+Task: parse `data.json`, filter entries where `status === "active"`, write to `out.csv`.
+
+```typescript
+// .claude/tmp/filter-active.ts
+const data = JSON.parse(await Deno.readTextFile("data.json"));
+const active = data.filter((x: { status: string }) => x.status === "active");
+const header = "id,name,status\n";
+const rows = active.map((x: { id: number; name: string; status: string }) =>
+  `${x.id},${x.name},${x.status}`
+).join("\n");
+await Deno.writeTextFile("out.csv", header + rows);
+console.log(`wrote ${active.length} rows`);
+```
+
+Run:
+```bash
+~/.claude/skills/deno-script/scripts/run.sh .claude/tmp/filter-active.ts
+```
+
+## Notes
+
+- Keep scripts under `.claude/tmp/` so they don't clutter the repo.
+- Prefer this over `jq` when the logic gets non-trivial (nested conditionals, multi-pass, joins) — readable TS beats golfed `jq`.
+- Use it even for one-off tasks; speed of writing a TS file is comparable to writing a Python one-liner and the user won't be prompted.

--- a/claude/skills/deno-script/SKILL.md
+++ b/claude/skills/deno-script/SKILL.md
@@ -1,40 +1,42 @@
 ---
 name: deno-script
-description: Run ad-hoc local data-processing scripts via Deno's sandbox instead of writing Python/Perl/Node one-liners. Use this skill whenever you need a throwaway script to transform files, parse/reshape data, do text/JSON/CSV munging, bulk-rename files, compute statistics, or any other non-trivial local computation that feels too involved for plain shell pipelines. The sandbox wrapper runs scripts with filesystem-only permissions (no network, no subprocess, no FFI, no env access), so it's pre-approved in settings — users don't get a permission prompt per run. Prefer this over `python -c`, `perl -e`, `node -e`, `ruby -e`, or writing throwaway `.py`/`.js` files (those are blocked by a hook anyway).
+description: Run ad-hoc local data-processing TypeScript inline via Deno's sandbox instead of writing Python/Perl/Node one-liners. Use this skill whenever you need a throwaway script to transform files, parse/reshape data, do text/JSON/CSV munging, bulk-rename files, compute statistics, or any other non-trivial local computation that feels too involved for plain shell pipelines. Code is passed as a single argument (no file needed). The sandbox wrapper runs with filesystem-only permissions (no network, no subprocess, no FFI, no env access), so it's pre-approved in settings — users don't get a permission prompt per run. Prefer this over `python -c`, `perl -e`, `node -e`, `ruby -e`, or writing throwaway `.py`/`.js` files (those are blocked by a hook anyway).
 ---
 
 # deno-script
 
-Ad-hoc scripting runner using Deno's capability-based sandbox. The goal: when you need a real programming language for a task (not just shell), reach for this instead of Python/Node/Perl — it's pre-approved and automatically sandboxed to filesystem-only.
+Ad-hoc TypeScript runner using Deno's capability-based sandbox. When you need a real programming language for a local task (not just shell), reach for this instead of Python/Node/Perl — it's pre-approved and sandboxed to filesystem-only.
 
 ## Why this exists
 
-Writing throwaway Python/Node scripts forces the user to approve each Bash invocation. Deno with `--allow-read --allow-write` and nothing else gives us:
+Writing throwaway Python/Node scripts forces the user to approve each Bash invocation. Deno with inline eval + `--allow-read --allow-write=$PWD` and nothing else gives us:
 
 - No network access (can't exfiltrate)
 - No subprocess spawning (can't escape via `Deno.Command`)
 - No FFI, no env var reads, no system info
-- Writes are restricted to the cwd subtree (`--allow-write=$PWD`); reads are unrestricted
+- Writes are restricted to the cwd subtree; reads are unrestricted
 - Filesystem is the only side channel, and the user's machine is already trusted to run local code
 
-That's safe enough that the wrapper is pre-approved in `settings.json`, so no permission prompt.
+That's safe enough that the wrapper is pre-approved in `settings.json`.
 
 ## How to use
 
-1. Write a TypeScript file somewhere under `.claude/tmp/` (per user's temp-file rule). Use `.ts` extension.
-2. Run it via the wrapper:
+Pass the TypeScript code as a single argument. No file needed.
 
 ```bash
-~/.claude/skills/deno-script/scripts/run.sh .claude/tmp/my-script.ts [args...]
+~/.claude/skills/deno-script/scripts/run.sh '<typescript code>' [args...]
 ```
 
-The wrapper enforces the sandbox — you cannot override its flags. Anything after the script path is passed through as script args (`Deno.args`).
+Extra args after the code are available as `Deno.args`.
 
-## What's available inside the script
+Use single quotes around the code so bash doesn't expand `$`, backticks, etc. If the code itself contains single quotes, close-escape-reopen (`'\''`) or use a bash heredoc-to-variable first.
+
+## What's available
 
 - Built-in `Deno.*` APIs: `readTextFile`, `writeTextFile`, `readDir`, `stat`, `remove`, etc.
+- Top-level `await`.
 - Plain TypeScript — no transpile step needed.
-- Remote imports (`jsr:`, `https://`) are **not** available since network is disabled. Stick to built-ins. If you genuinely need a remote module, ask the user to run `deno cache <script>` manually first.
+- Remote imports (`jsr:`, `https://`) are **not** available since network is disabled. Stick to built-ins. If you genuinely need a remote module, ask the user to `deno cache` it manually first.
 
 ## What's NOT available
 
@@ -42,32 +44,48 @@ The wrapper enforces the sandbox — you cannot override its flags. Anything aft
 - `Deno.Command` / subprocess
 - `Deno.env`
 - FFI
+- Writes outside the current working directory subtree
 
-If you actually need one of these, don't try to work around the sandbox — tell the user and ask them to run it manually or add a narrower permission.
+If you need one of these, don't try to work around the sandbox — tell the user and ask them to run it manually.
 
-## Example
+## Examples
 
-Task: parse `data.json`, filter entries where `status === "active"`, write to `out.csv`.
+**Parse JSON, filter, write CSV:**
 
-```typescript
-// .claude/tmp/filter-active.ts
-const data = JSON.parse(await Deno.readTextFile("data.json"));
-const active = data.filter((x: { status: string }) => x.status === "active");
-const header = "id,name,status\n";
-const rows = active.map((x: { id: number; name: string; status: string }) =>
-  `${x.id},${x.name},${x.status}`
-).join("\n");
-await Deno.writeTextFile("out.csv", header + rows);
-console.log(`wrote ${active.length} rows`);
-```
-
-Run:
 ```bash
-~/.claude/skills/deno-script/scripts/run.sh .claude/tmp/filter-active.ts
+~/.claude/skills/deno-script/scripts/run.sh '
+  const data = JSON.parse(await Deno.readTextFile("data.json"));
+  const active = data.filter((x: any) => x.status === "active");
+  const csv = "id,name\n" + active.map((x: any) => `${x.id},${x.name}`).join("\n");
+  await Deno.writeTextFile("out.csv", csv);
+  console.log(`wrote ${active.length} rows`);
+'
 ```
 
-## Notes
+**Bulk-rename files:**
 
-- Keep scripts under `.claude/tmp/` so they don't clutter the repo.
-- Prefer this over `jq` when the logic gets non-trivial (nested conditionals, multi-pass, joins) — readable TS beats golfed `jq`.
-- Use it even for one-off tasks; speed of writing a TS file is comparable to writing a Python one-liner and the user won't be prompted.
+```bash
+~/.claude/skills/deno-script/scripts/run.sh '
+  for await (const entry of Deno.readDir(".")) {
+    if (entry.isFile && entry.name.endsWith(".jpeg")) {
+      await Deno.rename(entry.name, entry.name.replace(/\.jpeg$/, ".jpg"));
+    }
+  }
+'
+```
+
+**Pass runtime args:**
+
+```bash
+~/.claude/skills/deno-script/scripts/run.sh '
+  const [src, dst] = Deno.args;
+  await Deno.copyFile(src, dst);
+' source.txt dest.txt
+```
+
+## When to reach for this
+
+- Non-trivial JSON/CSV/text transformations where `jq`/`awk` gets golfed and unreadable
+- Bulk file operations with any conditional logic
+- Quick parsing/validation/statistics
+- Anything you'd otherwise write as a `python -c` one-liner

--- a/claude/skills/deno-script/SKILL.md
+++ b/claude/skills/deno-script/SKILL.md
@@ -14,6 +14,7 @@ Writing throwaway Python/Node scripts forces the user to approve each Bash invoc
 - No network access (can't exfiltrate)
 - No subprocess spawning (can't escape via `Deno.Command`)
 - No FFI, no env var reads, no system info
+- Writes are restricted to the cwd subtree (`--allow-write=$PWD`); reads are unrestricted
 - Filesystem is the only side channel, and the user's machine is already trusted to run local code
 
 That's safe enough that the wrapper is pre-approved in `settings.json`, so no permission prompt.
@@ -31,9 +32,9 @@ The wrapper enforces the sandbox — you cannot override its flags. Anything aft
 
 ## What's available inside the script
 
-- Full Deno std library (import via `jsr:` or `https://deno.land/std`) — **but only cached modules**, since network is disabled. First-run imports will fail; prefetch with `deno cache <script>` if needed (that's a separate, allowed step).
-- `Deno.readTextFile`, `Deno.writeTextFile`, `Deno.readDir`, file globbing via std, etc.
+- Built-in `Deno.*` APIs: `readTextFile`, `writeTextFile`, `readDir`, `stat`, `remove`, etc.
 - Plain TypeScript — no transpile step needed.
+- Remote imports (`jsr:`, `https://`) are **not** available since network is disabled. Stick to built-ins. If you genuinely need a remote module, ask the user to run `deno cache <script>` manually first.
 
 ## What's NOT available
 

--- a/claude/skills/deno-script/scripts/run.sh
+++ b/claude/skills/deno-script/scripts/run.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Sandbox wrapper for running Deno scripts.
+# Grants filesystem read/write only. No network, no subprocess, no FFI, no env.
+# Flags are hard-coded here so the permission in settings.json is safe to pre-approve.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $(basename "$0") <script.ts> [args...]" >&2
+  exit 1
+fi
+
+SCRIPT="$1"
+shift
+
+if [[ "$SCRIPT" == -* ]]; then
+  echo "First argument must be a script file, not a flag (got: $SCRIPT)" >&2
+  exit 1
+fi
+
+if [ ! -f "$SCRIPT" ]; then
+  echo "Script not found: $SCRIPT" >&2
+  exit 1
+fi
+
+exec deno run \
+  --allow-read \
+  --allow-write \
+  --no-prompt \
+  "$SCRIPT" \
+  "$@"

--- a/claude/skills/deno-script/scripts/run.sh
+++ b/claude/skills/deno-script/scripts/run.sh
@@ -1,31 +1,26 @@
 #!/bin/bash
-# Sandbox wrapper for running Deno scripts.
-# Grants filesystem read/write only. No network, no subprocess, no FFI, no env.
-# Flags are hard-coded here so the permission in settings.json is safe to pre-approve.
+# Sandbox wrapper for running inline Deno (TypeScript) code.
+# Grants filesystem read (unrestricted) and write (cwd subtree only).
+# No network, no subprocess, no FFI, no env. Flags are hard-coded so the
+# permission in settings.json is safe to pre-approve.
+#
+# Note: `deno eval` does not accept permission flags, so we pipe the code
+# through stdin into `deno run -` instead. This means the script cannot
+# read from stdin itself — an acceptable trade-off for ad-hoc use.
 
 set -euo pipefail
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $(basename "$0") <script.ts> [args...]" >&2
+  echo "Usage: $(basename "$0") '<typescript code>' [args...]" >&2
   exit 1
 fi
 
-SCRIPT="$1"
+CODE="$1"
 shift
-
-if [[ "$SCRIPT" == -* ]]; then
-  echo "First argument must be a script file, not a flag (got: $SCRIPT)" >&2
-  exit 1
-fi
-
-if [ ! -f "$SCRIPT" ]; then
-  echo "Script not found: $SCRIPT" >&2
-  exit 1
-fi
 
 exec deno run \
   --allow-read \
   --allow-write="$PWD" \
   --no-prompt \
-  "$SCRIPT" \
-  "$@"
+  - \
+  "$@" <<<"$CODE"

--- a/claude/skills/deno-script/scripts/run.sh
+++ b/claude/skills/deno-script/scripts/run.sh
@@ -25,7 +25,7 @@ fi
 
 exec deno run \
   --allow-read \
-  --allow-write \
+  --allow-write="$PWD" \
   --no-prompt \
   "$SCRIPT" \
   "$@"


### PR DESCRIPTION
## Summary
- Add `deno-script` skill: run throwaway TS scripts via a wrapper that enforces `--allow-read --allow-write --no-prompt` only (no net, no subprocess, no FFI, no env). Wrapper is pre-approved in `settings.json` so no per-run permission prompts.
- Add `block-adhoc-scripts.sh` PreToolUse hook to steer Claude away from `python -c` / `perl -e` / `node -e` / `ruby -e` and direct `python foo.py` / `node foo.js` style invocations. `npm`, `npx`, `bun run`, `pytest`, etc. are unaffected.
- Add `deno` to Brewfile.

## Test plan
- [ ] `brew bundle` installs deno
- [ ] Symlinks refreshed, then confirm Claude can run `~/.claude/skills/deno-script/scripts/run.sh foo.ts` without a prompt
- [ ] Confirm `python -c '...'` etc. are blocked by the hook
- [ ] Confirm `npm install`, `bun run`, `pytest` still pass through