### PR TITLE
configure Claude Code as Zed external agent

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -105,5 +105,13 @@
       // vimrc.keymap: jf -> <ESC>
       "j f": "vim::NormalBefore"
     }
+  },
+  {
+    "bindings": {
+      "cmd-alt-c": [
+        "agent::NewExternalAgentThread",
+        { "agent": { "custom": { "name": "claude-acp" } } }
+      ]
+    }
   }
 ]

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,4 +1,21 @@
 {
+  "project_panel": {
+    "dock": "left"
+  },
+  "outline_panel": {
+    "dock": "left"
+  },
+  "collaboration_panel": {
+    "dock": "left"
+  },
+  "agent": {
+    "dock": "right",
+    "favorite_models": [],
+    "model_parameters": []
+  },
+  "git_panel": {
+    "dock": "left"
+  },
   "$schema": "zed://schemas/settings",
   "telemetry": {
     "diagnostics": false,
@@ -17,5 +34,13 @@
     "mode": "system",
     "light": "One Light",
     "dark": "One Dark",
+  },
+  "agent_servers": {
+    "claude-acp": {
+      "type": "registry",
+      "env": {
+        "CLAUDE_CODE_EXECUTABLE": "$HOME/.local/bin/claude"
+      }
+    }
   },
 }

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -39,7 +39,7 @@
     "claude-acp": {
       "type": "registry",
       "env": {
-        "CLAUDE_CODE_EXECUTABLE": "$HOME/.local/bin/claude"
+        "CLAUDE_CODE_EXECUTABLE": "~/.local/bin/claude"
       }
     }
   },


### PR DESCRIPTION
Adds Zed agent_servers config registering Claude Code (claude-acp) and a cmd-alt-c keybinding to open a new external agent thread. Uses the locally installed claude executable via CLAUDE_CODE_EXECUTABLE.