### PR TITLE
zed: add , D branch diff binding, visual-mode keymap and settings tweaks

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -56,7 +56,7 @@
       "r": "editor::Rename",                     // RenameElement
       "q": "editor::ToggleCodeActions",          // ShowIntentionActions
       "= =": "editor::Format",                   // ReformatCode
-      // cc removed: conflicts with vim's c operator (use gcc / gc<motion> instead)
+      // cc removed: conflicts with vim's c operator (breaks ciw etc.) — use gcc instead
       "ctrl-i": "editor::Hover",                 // QuickJavaDoc
 
       // ideavimrc: bookmarks/breakpoints
@@ -78,12 +78,14 @@
 
       ", a": "command_palette::Toggle",
 
-      // cc removed: conflicts with vim's c operator (use gc<motion> instead)
+      "c c": "editor::ToggleComments", // toggle comment for selection
       // ideavimrc: p -> EditorSelectWord (expand), n -> EditorUnSelectWord (shrink)
       "p": "editor::SelectLargerSyntaxNode",
       "n": "editor::SelectSmallerSyntaxNode",
       // vimrc.keymap: vmap s S (surround)
-      "s": ["workspace::SendKeystrokes", "shift-s"]
+      "s": ["workspace::SendKeystrokes", "shift-s"],
+      // visual mode shift-s: add surrounds (vim-surround)
+      "shift-s": "vim::PushAddSurrounds"
     }
   },
   {

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -34,6 +34,7 @@
       ", z": "projects::OpenRecent",             // RecentProjectListGroup
       ", t": "project_panel::ToggleFocus",       // project tree
       ", d": "git_panel::ToggleFocus",           // git diff
+      ", shift-d": "git::BranchDiff",            // diff against base branch
 
       // normal mode: cmd-> selects current line and adds to agent thread
       "cmd->": ["workspace::SendKeystrokes", "shift-v cmd->"],

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,4 +1,5 @@
 {
+  "icon_theme": "Zed (Default)",
   "cli_default_open_behavior": "new_window",
   "auto_install_extensions": {
     "xml": true,
@@ -44,12 +45,15 @@
     "calt": true,
   },
   "theme": {
-    "mode": "system",
+    "mode": "dark",
     "light": "One Light",
     "dark": "Ayu Mirage",
   },
   "agent_servers": {
     "claude-acp": {
+      "default_config_options": {
+        "mode": "auto"
+      },
       "type": "registry",
     },
   },


### PR DESCRIPTION
## Summary
- Add normal-mode `, D` binding for `git::BranchDiff` (diff against base branch), pairing with the existing `, d` git panel toggle
- Add visual-mode `c c` for `editor::ToggleComments` and `shift-s` for `vim::PushAddSurrounds`
- Switch Zed theme mode to dark, set `Zed (Default)` icon theme, and enable `claude-acp` auto mode

## Test plan
- [ ] Reload Zed and press `, D` in normal mode to confirm branch diff opens
- [ ] In visual mode, `cc` toggles comment on selection; `S` adds surrounds
- [ ] Settings load without warnings