### PR TITLE
add Dock autohide delay and animation speed settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ A dotfiles repository for managing macOS development environment setup. Running 
 - `claude/` — Global Claude Code settings (symlinked to `~/.claude/`)
 - Per-tool config directories (`git/`, `zsh/`, `vim/`, `ghostty/`, `karabiner/`, `vscode/`, `starship/`, `peco/`, `ag/`, `intellij/`, `jupyter/`, `qmk/`) — Configuration files for each tool
 
+## Language
+
+- Everything in this project is written in English, including code comments, commit messages, PR titles, and PR descriptions. Always write in English regardless of the language used in the conversation.
+
 ## Note
 
 - This is a dotfiles repo, so there are two kinds of config files that can be confused:

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -38,8 +38,8 @@ symlink(`${home}/.dotfiles/claude/skills`, `${home}/.claude/skills`),
   symlink(`${home}/.dotfiles/vscode/tasks.json`, `${home}/Library/Application Support/Code/User/tasks.json`),
   // osx defaults
   defaults("com.apple.dock", "autohide", {bool: true}),
-  defaults("com.apple.dock", "autohide-delay", {float: 0}), // Dock自動非表示の表示遅延をなくす
-  defaults("com.apple.dock", "autohide-time-modifier", {float: 0.15}), // Dockの非表示/表示アニメーションを速くする
+  defaults("com.apple.dock", "autohide-delay", {float: 0}), // Remove the show delay when moving the cursor to the screen edge
+  defaults("com.apple.dock", "autohide-time-modifier", {float: 0.15}), // Speed up the Dock hide/show animation
   defaults("com.apple.dock", "persistent-apps", {array: "", expected: "(\n)"}),
   defaults("com.apple.dock", "tilesize", {int: 55}),
   defaults("com.apple.finder", "AppleShowAllFiles", {bool: true}),

--- a/provisioner/src/main.ts
+++ b/provisioner/src/main.ts
@@ -38,6 +38,8 @@ symlink(`${home}/.dotfiles/claude/skills`, `${home}/.claude/skills`),
   symlink(`${home}/.dotfiles/vscode/tasks.json`, `${home}/Library/Application Support/Code/User/tasks.json`),
   // osx defaults
   defaults("com.apple.dock", "autohide", {bool: true}),
+  defaults("com.apple.dock", "autohide-delay", {float: 0}), // Dock自動非表示の表示遅延をなくす
+  defaults("com.apple.dock", "autohide-time-modifier", {float: 0.15}), // Dockの非表示/表示アニメーションを速くする
   defaults("com.apple.dock", "persistent-apps", {array: "", expected: "(\n)"}),
   defaults("com.apple.dock", "tilesize", {int: 55}),
   defaults("com.apple.finder", "AppleShowAllFiles", {bool: true}),

--- a/provisioner/src/task.ts
+++ b/provisioner/src/task.ts
@@ -66,6 +66,7 @@ export const symlink = (src: string, dest: string): Task => {
 type DefaultsValue =
   | { bool: boolean }
   | { int: number }
+  | { float: number }
   | { string: string }
   | { array: string; expected: string };
 
@@ -84,6 +85,7 @@ export const defaults = (domain: string, key: string, value: DefaultsValue): Tas
 const toDefaultsArgs = (value: DefaultsValue): { writeArgs: string; expected: string } => {
   if ("bool" in value) return {writeArgs: `-bool ${value.bool}`, expected: value.bool ? "1" : "0"};
   if ("int" in value) return {writeArgs: `-int ${value.int}`, expected: String(value.int)};
+  if ("float" in value) return {writeArgs: `-float ${value.float}`, expected: String(value.float)};
   if ("string" in value) return {writeArgs: `-string '${value.string}'`, expected: value.string};
   return {writeArgs: `-array ${value.array}`, expected: value.expected};
 };


### PR DESCRIPTION
Add Dock auto-hide related settings.

- `autohide-delay` = 0 - removes the show delay when moving the cursor to the screen edge
- `autohide-time-modifier` = 0.15 - speeds up the hide/show animation
- Add `-float` value support to the `defaults` task

`autohide` (auto-hide itself) was already configured, so it is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)