### PR TITLE
rebind , d to project diff and tweak zed font settings

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -33,7 +33,7 @@
       ", f": "file_finder::Toggle",              // GotoFile
       ", z": "projects::OpenRecent",             // RecentProjectListGroup
       ", t": "project_panel::ToggleFocus",       // project tree
-      ", d": "git_panel::ToggleFocus",           // git diff
+      ", d": "git::Diff",                        // open project diff (working dir vs index) in editor
       ", shift-d": "git::BranchDiff",            // diff against base branch
 
       // normal mode: cmd-> selects current line and adds to agent thread

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -36,13 +36,12 @@
   "base_keymap": "JetBrains",
   "ui_font_size": 14,
   "ui_font_family": "JetBrains Mono",
-  "buffer_font_size": 12,
+  "ui_font_weight": 300,
+  "buffer_font_size": 13,
   "buffer_font_family": "JetBrains Mono",
+  "buffer_font_weight": 300,
   "buffer_font_features": {
     "calt": false,
-  },
-  "ui_font_features": {
-    "calt": true,
   },
   "theme": {
     "mode": "dark",
@@ -52,7 +51,7 @@
   "agent_servers": {
     "claude-acp": {
       "default_config_options": {
-        "mode": "auto"
+        "mode": "auto",
       },
       "type": "registry",
     },


### PR DESCRIPTION
## Summary
- Rebind `, d` to open the project diff (working dir vs index) in an editor instead of focusing the git panel
- Add `ui_font_weight` / `buffer_font_weight` (300) and bump `buffer_font_size` to 13 for a lighter JetBrains Mono look

🤖 Generated with [Claude Code](https://claude.com/claude-code)