### PR TITLE
Tune Zed modified file color to JetBrains blue

### DIFF
--- a/zed/themes/rustrover-dark.json
+++ b/zed/themes/rustrover-dark.json
@@ -89,7 +89,7 @@
         "warning.background": "#52433d",
         "success": "#73bd79",
         "created": "#629755",
-        "modified": "#6897bb",
+        "modified": "#7eacf9",
         "deleted": "#6c6c6c",
         "conflict": "#d5756c",
         "hint": "#868a91",


### PR DESCRIPTION
## Summary

Tune the Zed RustRover Dark theme's git "modified" file color to match JetBrains.

- Set the `modified` status color to `#7eacf9`, sampled directly from a RustRover project tree screenshot (the `clippy.toml` blue label), replacing the desaturated Darcula value
- Changed files in the Zed project tree now match the JetBrains editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)
