### PR TITLE
Add agent thread switcher keymap (cmd-j / cmd-shift-j)

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -132,5 +132,14 @@
         { "agent": { "custom": { "name": "claude-acp" } } }
       ]
     }
+  },
+  {
+    // agent thread switcher: no context so it matches at the lowest tree level,
+    // overriding the default cmd-j (ToggleBottomDock) and staying active while the
+    // switcher popup is open. hold cmd, j -> next / shift-j -> prev, release to confirm
+    "bindings": {
+      "cmd-j": "agents_sidebar::ToggleThreadSwitcher",
+      "cmd-shift-j": ["agents_sidebar::ToggleThreadSwitcher", { "select_last": true }]
+    }
   }
 ]


### PR DESCRIPTION
Add cmd-j / cmd-shift-j keybindings to cycle through agent threads via the thread switcher popup.

- `cmd-j` -> next thread, `cmd-shift-j` -> previous (select_last)
- Bound with no context so it matches at the lowest tree level, overriding the default `cmd-j` (ToggleBottomDock) and staying active while the switcher popup is open
- Hold cmd to cycle, release to confirm (same hold-to-cycle UX as the default ctrl-tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
