### PR TITLE
Add cmd-o to toggle focus between editor and terminal

### DIFF
--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -141,5 +141,13 @@
       "cmd-j": "agents_sidebar::ToggleThreadSwitcher",
       "cmd-shift-j": ["agents_sidebar::ToggleThreadSwitcher", { "select_last": true }]
     }
+  },
+  {
+    // cmd-o toggles focus between editor and panels (e.g. terminal).
+    // no context so it matches at the lowest tree level and overrides the
+    // default cmd-o = workspace::Open (which is a no-context binding too)
+    "bindings": {
+      "cmd-o": "editor::ToggleFocus"
+    }
   }
 ]


### PR DESCRIPTION
Bind `cmd-o` to `editor::ToggleFocus` so focus can be toggled between the editor and panels (e.g. the terminal).

- From the terminal, `cmd-o` returns focus to the editor; from the editor it jumps back to the last panel
- Bound with no context so it matches at the lowest tree level, overriding the default no-context `cmd-o` = `workspace::Open`
- Tradeoff: the default `cmd-o` open-dialog is no longer available (file opening is already covered by the `,f` file finder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
